### PR TITLE
Add Docker and compose setup for LLM proxy and services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ config/llm_proxy_*.yml
 __pycache__/*
 transcripts/*
 logs/*
+!logs/.gitkeep
 Testing/
 my_personas/
 ollama_translate_service.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.11-slim
+
+# Set work directory
+WORKDIR /app
+
+# Install system dependencies required for pyttsx3/espeak
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    espeak-ng \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Default entrypoint runs the proxy; service containers override command
+ENTRYPOINT ["python"]
+CMD ["llm_proxy.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,64 @@
+version: "3.9"
+
+services:
+  llm_proxy:
+    build: .
+    image: llm-meetup
+    container_name: llm_proxy
+    command: ["llm_proxy.py", "-H", "0.0.0.0", "-p", "18888"]
+    ports:
+      - "18888:18888"
+    volumes:
+      - ./config:/app/config
+      - ./personas:/app/personas
+      - ./logs:/app/logs
+    networks:
+      - traefik_public
+    labels:
+      - "traefik.enable=true"
+      - "traefik.tcp.routers.llm_proxy.rule=HostSNI(`*`)"
+      - "traefik.tcp.routers.llm_proxy.entrypoints=llm-proxy"
+      - "traefik.tcp.services.llm_proxy.loadbalancer.server.port=18888"
+      - "traefik.docker.network=traefik_public"
+
+  openai_service:
+    image: llm-meetup
+    entrypoint: ["python", "openai_service.py"]
+    command: ["personas/einstein_en.md", "-H", "llm_proxy", "-p", "18888"]
+    volumes:
+      - ./config:/app/config
+      - ./personas:/app/personas
+      - ./logs:/app/logs
+    networks:
+      - traefik_public
+    depends_on:
+      - llm_proxy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.tcp.routers.openai.rule=HostSNI(`openai`)"
+      - "traefik.tcp.routers.openai.entrypoints=openai"
+      - "traefik.tcp.services.openai.loadbalancer.server.port=18888"
+      - "traefik.docker.network=traefik_public"
+
+  anthropic_service:
+    image: llm-meetup
+    entrypoint: ["python", "anthropic_service.py"]
+    command: ["personas/einstein_en.md", "-H", "llm_proxy", "-p", "18888"]
+    volumes:
+      - ./config:/app/config
+      - ./personas:/app/personas
+      - ./logs:/app/logs
+    networks:
+      - traefik_public
+    depends_on:
+      - llm_proxy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.tcp.routers.anthropic.rule=HostSNI(`anthropic`)"
+      - "traefik.tcp.routers.anthropic.entrypoints=anthropic"
+      - "traefik.tcp.services.anthropic.loadbalancer.server.port=18888"
+      - "traefik.docker.network=traefik_public"
+
+networks:
+  traefik_public:
+    external: true


### PR DESCRIPTION
## Summary
- Provide Dockerfile to build Python application with dependencies and default proxy entrypoint
- Introduce docker-compose stack with llm_proxy, OpenAI and Anthropic service containers and Traefik routing on `traefik_public`
- Track log directory placeholder via .gitkeep

## Testing
- `python -m py_compile llm_proxy.py openai_service.py anthropic_service.py lmstudio_service.py ollama_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac898dd00883289a4cecfec33a0c97