### PR TITLE
Add env example template and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ python anthropic_service.py personas/psychotherapist.md --host localhost --port 
 ```
 
 ### Docker
-`docker-compose` reads settings from a `.env` file. Copy `.env.example` to `.env`, set your keys, then run:
+`docker-compose` reads settings from a `.env` file. Copy `env.example` to `.env` and customize the values, then run:
 
 ```bash
 docker-compose up --build
 ```
 
 ## Configuration
-Services read default configuration from environment variables before parsing command line options. Create a `.env` file (see `.env.example`) to set values:
+Services read default configuration from environment variables before parsing command line options. Create a `.env` file (see `env.example`) to set values:
 
 | Variable | Purpose |
 | --- | --- |

--- a/env.example
+++ b/env.example
@@ -1,0 +1,24 @@
+# Environment variables for LLM-Meetup
+# Copy this file to .env and fill in the required values
+
+# Proxy configuration
+LLM_PROXY_HOST=127.0.0.1
+LLM_PROXY_PORT=18888
+TRAFFIC_DOMAIN=example.com
+
+# OpenAI
+OPENAI_API_KEY=your-openai-key
+OPENAI_MODEL=gpt-4o-mini
+OPENAI_API_BASE=https://api.openai.com/v1
+
+# Anthropic
+ANTHROPIC_API_KEY=your-anthropic-key
+ANTHROPIC_MODEL=claude-3-5-sonnet
+
+# Ollama
+OLLAMA_MODEL=dolphin-llama3
+OLLAMA_API_HOST=http://localhost:11434
+
+# LM Studio
+LMSTUDIO_MODEL=lmstudio-model
+LMSTUDIO_API_BASE=http://localhost:1234


### PR DESCRIPTION
## Summary
- add `env.example` template listing proxy host/port, model settings, API keys, and Traefik routing domain
- update README to instruct copying `env.example` to `.env`

## Testing
- `flake8`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac9daa1dd08328ad0a646d98f4b5f7