### PR TITLE
Consolidate container stack and Traefik integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,14 @@ python anthropic_service.py personas/psychotherapist.md --host localhost --port 
 ```
 
 ### Docker
-`docker-compose` reads settings from a `.env` file. Copy `env.example` to `.env` and customize the values, then run:
+`docker-compose` reads settings from a `.env` file. Copy `env.example` to `.env` and customize the values, then start the stack:
 
 ```bash
-docker-compose up --build
+docker-compose up --build -d
+
+# in separate terminals run services inside the container
+docker-compose exec llm_meetup python openai_service.py personas/einstein_en.md --host llm_meetup --port ${LLM_PROXY_PORT}
+docker-compose exec llm_meetup python anthropic_service.py personas/psychotherapist.md --host llm_meetup --port ${LLM_PROXY_PORT}
 ```
 
 ## Configuration
@@ -94,6 +98,9 @@ This has only been tested on a Mac. It uses voices provided by macOS. You need t
 
 ## Outlook
 There will be more to come. Feedback is welcome.
+
+### Roadmap
+- Expand the web UI so conversations can be configured and controlled when running in containers.
 
 #### Version and last edited
 This is version: v0.5.1 (build: 61) by rheiger@icloud.com on 2024-08-29 13:58:46

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,13 @@
 version: "3.9"
 
 services:
-  llm_proxy:
+  llm_meetup:
     build: .
     image: llm-meetup
-    container_name: llm_proxy
-    command: ["llm_proxy.py", "-H", "0.0.0.0", "-p", "18888"]
+    container_name: llm_meetup
+    command: ["llm_proxy.py", "-H", "${LLM_PROXY_HOST}", "-p", "${LLM_PROXY_PORT}"]
     ports:
-      - "18888:18888"
+      - "${LLM_PROXY_PORT}:${LLM_PROXY_PORT}"
     volumes:
       - ./config:/app/config
       - ./personas:/app/personas
@@ -16,47 +16,9 @@ services:
       - traefik_public
     labels:
       - "traefik.enable=true"
-      - "traefik.tcp.routers.llm_proxy.rule=HostSNI(`*`)"
-      - "traefik.tcp.routers.llm_proxy.entrypoints=llm-proxy"
-      - "traefik.tcp.services.llm_proxy.loadbalancer.server.port=18888"
-      - "traefik.docker.network=traefik_public"
-
-  openai_service:
-    image: llm-meetup
-    entrypoint: ["python", "openai_service.py"]
-    command: ["personas/einstein_en.md", "-H", "llm_proxy", "-p", "18888"]
-    volumes:
-      - ./config:/app/config
-      - ./personas:/app/personas
-      - ./logs:/app/logs
-    networks:
-      - traefik_public
-    depends_on:
-      - llm_proxy
-    labels:
-      - "traefik.enable=true"
-      - "traefik.tcp.routers.openai.rule=HostSNI(`openai`)"
-      - "traefik.tcp.routers.openai.entrypoints=openai"
-      - "traefik.tcp.services.openai.loadbalancer.server.port=18888"
-      - "traefik.docker.network=traefik_public"
-
-  anthropic_service:
-    image: llm-meetup
-    entrypoint: ["python", "anthropic_service.py"]
-    command: ["personas/einstein_en.md", "-H", "llm_proxy", "-p", "18888"]
-    volumes:
-      - ./config:/app/config
-      - ./personas:/app/personas
-      - ./logs:/app/logs
-    networks:
-      - traefik_public
-    depends_on:
-      - llm_proxy
-    labels:
-      - "traefik.enable=true"
-      - "traefik.tcp.routers.anthropic.rule=HostSNI(`anthropic`)"
-      - "traefik.tcp.routers.anthropic.entrypoints=anthropic"
-      - "traefik.tcp.services.anthropic.loadbalancer.server.port=18888"
+      - "traefik.tcp.routers.llm_meetup.rule=HostSNI(`${TRAFFIC_DOMAIN}`)"
+      - "traefik.tcp.routers.llm_meetup.entrypoints=llm-meetup"
+      - "traefik.tcp.services.llm_meetup.loadbalancer.server.port=${LLM_PROXY_PORT}"
       - "traefik.docker.network=traefik_public"
 
 networks:

--- a/env.example
+++ b/env.example
@@ -2,8 +2,9 @@
 # Copy this file to .env and fill in the required values
 
 # Proxy configuration
-LLM_PROXY_HOST=127.0.0.1
+LLM_PROXY_HOST=0.0.0.0
 LLM_PROXY_PORT=18888
+# Public domain Traefik uses for routing
 TRAFFIC_DOMAIN=example.com
 
 # OpenAI


### PR DESCRIPTION
## Summary
- run entire app in single `llm_meetup` container and remove public exposure for per-provider services
- use `TRAFFIC_DOMAIN` variable for Traefik routing
- document container usage and add roadmap item for a future web UI

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'PY'
import yaml, os
for line in open('env.example'):
    line=line.strip()
    if line and not line.startswith('#') and '=' in line:
        k,v=line.split('=',1)
        os.environ.setdefault(k,v)
with open('docker-compose.yml') as f:
    yaml.safe_load(f)
print('docker-compose.yml parsed successfully')
PY`
- `docker-compose --env-file env.example config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac762c669c8328b84c228e47badc76