### PR TITLE
Add documentation planning guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,12 @@
 # 🤖 AI Agent Guidelines for LLM-Meetup
 
+## Documentation & Planning
+
+- Use the `Documents/` directory to manually track issues, milestones, and progress.
+- `Documents/BRAINSTORM.md` lists feature ideas with links to related issues and milestones.
+- Update or create Markdown files in `Documents/` when plans or statuses change.
+- Prefer concise bullet points and reference issue numbers where applicable.
+
 ## Product Owner
 `project_description`, `user_stories`, `user_tasks`
 

--- a/Documents/AGENTS.md
+++ b/Documents/AGENTS.md
@@ -1,0 +1,7 @@
+# Documentation Guidelines
+
+- This directory stores planning and tracking documents for the project.
+- `BRAINSTORM.md` captures feature ideas along with related issue and milestone references.
+- When documenting progress, create or update Markdown files in this directory.
+- Keep entries concise, prefer bullet lists, and reference issue numbers when relevant.
+- Ensure each document maintains a clear record of decisions and status updates.


### PR DESCRIPTION
## Summary
- Outline manual planning workflow in `Documents/`
- Introduce document-specific guidance via `Documents/AGENTS.md`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acd93e0908832896c47a0b78196294