### PR TITLE
Add documentation planning checklist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,12 @@
 # 🤖 AI Agent Guidelines for LLM-Meetup
 
+## Documentation & Planning
+
+- Use the `Documents/` directory to manually track issues, milestones, and progress.
+- `Documents/BRAINSTORM.md` lists feature ideas with links to related issues and milestones.
+- Update or create Markdown files in `Documents/` when plans or statuses change.
+- Prefer concise bullet points and reference issue numbers where applicable.
+
 ## Product Owner
 `project_description`, `user_stories`, `user_tasks`
 

--- a/Documents/AGENTS.md
+++ b/Documents/AGENTS.md
@@ -1,0 +1,8 @@
+# Documentation Guidelines
+
+- This directory stores planning and tracking documents for the project.
+- `BRAINSTORM.md` captures feature ideas along with related issue and milestone references.
+- `PLAN.md` tracks actionable tasks using Markdown checkboxes.
+- When documenting progress, create or update Markdown files in this directory.
+- Keep entries concise, prefer bullet lists, and reference issue numbers when relevant.
+- Ensure each document maintains a clear record of decisions and status updates.

--- a/Documents/PLAN.md
+++ b/Documents/PLAN.md
@@ -1,0 +1,16 @@
+# Implementation Plan
+
+Based on `BRAINSTORM.md`, the following tasks will guide development. Track progress by marking each checkbox.
+
+- [ ] Issue #7: Implement ChatML-style message protocol
+- [ ] Issue #8: Create FastAPI backend and Tailwind front end
+- [ ] Issue #10: Limit concurrent sessions to two & restrict API usage by IP/domain
+- [ ] Issue #9: Add landing page with usage instructions
+- [ ] Issue #11: Build conversation configuration UI (persona, models, language, rounds, starter)
+- [ ] Issue #12: Support user-supplied personas and system prompts
+- [ ] Issue #13: Implement optional TTS with voice selection
+- [ ] Issue #14: Collect and expose usage statistics
+- [ ] Issue #15: Add user authentication (passkeys, OAuth, OTP) and API-key integration
+- [ ] Issue #16: Secure storage of user API keys
+- [ ] Issue #17: Conversation download as PDF/Markdown
+


### PR DESCRIPTION
## Summary
- Introduce `PLAN.md` to track brainstormed issues with checkbox tasks
- Link `PLAN.md` in document guidelines for consistent planning docs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acd93e0908832896c47a0b78196294